### PR TITLE
Update docs for v1.4.2

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -8,6 +8,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/) and semantic-
 ## [1.4.2] – 2025‑06‑11
 ### Added
 * **Preprocessor variable index** – LESS and SCSS variables are indexed for instant look‑ups.
+* **Value‑based completion sorting** – variables sort by numeric value with ascending/descending option.
+* **Pixel equivalent column** – documentation shows px values for rem/em/% sizes.
 
 ### Improved
 * More reliable `var()` detection and prefix extraction while typing.

--- a/README.MD
+++ b/README.MD
@@ -18,6 +18,8 @@ Boosts CSS Custom Properties with smart completion, rich documentation and full 
 |----------|------------|
 | **🛠️ Preprocessor index** | LESS/SCSS variables are indexed for instant resolution. |
 | **🔍 Smarter var() detection** | Completion works while typing incomplete `var(` and resolves aliases quicker. |
+| **📏 Value-based sorting** | Completions sort by numeric value with ascending/descending option. |
+| **📐 Docs show px equivalents** | Non‑px size values display their pixel conversion. |
 
 ---
 ## ✨ What's new in 1.4.1
@@ -81,6 +83,7 @@ Open **Settings → Tools → CSS Variables Assistant**
 | **Max @import depth** | 1 – 20 (default 20)                                                |
 | **Show context values** | Display dark/light & media-query variants                          |
 | **Allow IDE built-in completions** | Fall back to IntelliJ suggestions for misses                       |
+| **Completion sorting** | Ascending or descending value order |
 | **🔄 Re-index Now** | Flush caches and rebuild the variable index immediately            |
 
 ---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,11 +66,13 @@ intellijPlatform {
         }
 
         changeNotes = """
-<h2>1.4.3 – 2025-06-11</h2>
+<h2>1.4.2 – 2025-06-11</h2>
 
 <h3>Added</h3>
 <ul>
   <li><strong>Preprocessor index</strong> – LESS/SCSS variables are indexed for instant resolution.</li>
+  <li><strong>Value‑based sorting</strong> – completions sort by numeric value with asc/desc option.</li>
+  <li><strong>Pixel equivalents</strong> shown in documentation for rem/em/% values.</li>
 </ul>
 
 <h3>Improved</h3>
@@ -81,7 +83,7 @@ intellijPlatform {
 
 <h3>Fixed</h3>
 <ul>
-  <li>Race conditions in scope calculation and duplicate IDE completions.</li>
+  <li>Scope caching race conditions and duplicate IDE completions.</li>
 </ul>
 """.trimIndent()
 


### PR DESCRIPTION
## Summary
- update changelog, README and build.gradle.kts for release 1.4.2
- document value-based sorting and pixel-equivalent docs
- document new setting in configuration table

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6849fec6e0648325bdfa4607fbadeec6