### PR TITLE
Finalize docs for v1.4.2 release

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,7 +9,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/) and semantic-
 ### Added
 * **Preprocessor variable index** – LESS and SCSS variables are indexed for instant look‑ups.
 * **Value‑based completion sorting** – variables sort by numeric value with ascending/descending option.
-* **Pixel equivalent column** – documentation shows px values for rem/em/%/vh/vw/dvh sizes.
+* **Pixel equivalent column** – documentation now shows the px value when a size isn't in px.
 
 ### Improved
 * More reliable `var()` detection and prefix extraction while typing.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,7 +5,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/) and semantic-
 
 ---
 
-## [1.4.2] – 2025‑06‑11
+## [1.4.2] – 2025‑06‑12
 ### Added
 * **Preprocessor variable index** – LESS and SCSS variables are indexed for instant look‑ups.
 * **Value‑based completion sorting** – variables sort by numeric value with ascending/descending option.

--- a/README.MD
+++ b/README.MD
@@ -70,6 +70,8 @@ See full details in [`CHANGELOG.MD`](./CHANGELOG.MD).
 * **Recursive var() & pre-processor alias resolution**
 * **JSDoc-style tags** `@name`, `@description`, `@example`
 * Works inside **CSS / SCSS / SASS / LESS / JS / TS / JSX / TSX**
+* **Preprocessor variable index** for instant LESS/SCSS variable look-ups
+* **Value-based sorting** with pixel equivalents for intuitive ordering
 
 ---
 

--- a/README.MD
+++ b/README.MD
@@ -66,6 +66,7 @@ See full details in [`CHANGELOG.MD`](./CHANGELOG.MD).
 
 * **Context-aware completion** inside `var(-- … )`
 * **Quick Documentation** (<kbd>Ctrl Q</kbd> / hover) with table, swatches, description & examples
+* **Pixel equivalents** displayed in documentation for non-px size values
 * **@import traversal** for CSS, SCSS, SASS & LESS with smart extension inference
 * **Recursive var() & pre-processor alias resolution**
 * **JSDoc-style tags** `@name`, `@description`, `@example`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ intellijPlatform {
 <ul>
   <li><strong>Preprocessor index</strong> – LESS/SCSS variables are indexed for instant resolution.</li>
   <li><strong>Value‑based sorting</strong> – completions sort by numeric value with asc/desc option.</li>
-  <li><strong>Pixel equivalents</strong> shown in documentation for rem/em/%/vw/vh/dvh values.</li>
+  <li><strong>Pixel equivalents</strong> column shows px values whenever a size isn't in px.</li>
 </ul>
 
 <h3>Improved</h3>


### PR DESCRIPTION
## Summary
- document preprocessor index and value-based sorting
- finalize change log for v1.4.2
- tweak README overview bullets

## Testing
- `./gradlew test --no-daemon` *(fails: gradle download requires network)*

------
https://chatgpt.com/codex/tasks/task_e_684a870212dc8325b5284f22643947f0