### PR TITLE
Fix completion main value display

### DIFF
--- a/src/main/kotlin/cssvarsassistant/completion/CssVariableCompletion.kt
+++ b/src/main/kotlin/cssvarsassistant/completion/CssVariableCompletion.kt
@@ -172,10 +172,19 @@ class CssVariableCompletion : CompletionContributor() {
                                     valuePairs.distinctBy { (ctx, v) -> ctx to v }
                                 val values = uniqueValuePairs.map { it.second }.distinct()
 
-                                val mainValue = uniqueValuePairs.find { it.first == "default" }?.second
+                                fun isAlias(v: String): Boolean {
+                                    val t = v.trim()
+                                    return t.startsWith("@") || t.startsWith("$") || t.startsWith("var(")
+                                }
+
+                                val mainValue = uniqueValuePairs
+                                    .filter { it.first == "default" }
+                                    .firstOrNull { !isAlias(it.second) }
+                                    ?.second
+                                    ?: uniqueValuePairs.find { it.first == "default" }?.second
                                     ?: values.first()
 
-                                val cleanMainValue = mainValue.trim().replace(Regex("""\s*\(.*\)$"""), "")
+                                val cleanMainValue = mainValue.trim()
 
                                 val docEntry = allVals.firstOrNull {
                                     it.substringAfter(DELIMITER).substringAfter(DELIMITER).isNotBlank()


### PR DESCRIPTION
## Summary
- favor literal values for completion display
- retain value text with functions/aliases

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684ad53d705c8325a843be412d9a6d8a