### PR TITLE
fix: prevent minified css files that start with comments from not being indexed

### DIFF
--- a/src/main/kotlin/cssvarsassistant/index/CssVariableIndex.kt
+++ b/src/main/kotlin/cssvarsassistant/index/CssVariableIndex.kt
@@ -157,22 +157,26 @@ class CssVariableIndex : FileBasedIndexExtension<String, String>() {
 
             // Comment Extraction
             if (!inBlockComment && (line.startsWith("/*") || line.startsWith("/**"))) {
-                inBlockComment = true
-                blockComment.clear()
                 if (line.contains("*/")) {
-                    blockComment.append(
-                        line
-                            .removePrefix("/**").removePrefix("/*")
-                            .removeSuffix("*/").trim()
-                    )
-                    lastComment = blockComment.toString().trim()
-                    inBlockComment = false
-                    continue
+                    // Single-line comment: extract it and remove from line, then continue
+                    // processing
+                    val commentEnd = line.indexOf("*/") + 2
+                    val comment =
+                            line.substring(0, commentEnd)
+                                    .removePrefix("/**")
+                                    .removePrefix("/*")
+                                    .removeSuffix("*/")
+                                    .trim()
+                    lastComment = comment
+                    line =
+                            line.substring(commentEnd)
+                                    .trim() // Remove comment, continue with rest of line
+                    // Don't continue - process the rest of the line
                 } else {
-                    blockComment.append(
-                        line
-                            .removePrefix("/**").removePrefix("/*").trim()
-                    )
+                    // Multi-line comment start
+                    inBlockComment = true
+                    blockComment.clear()
+                    blockComment.append(line.removePrefix("/**").removePrefix("/*").trim())
                     continue
                 }
             }


### PR DESCRIPTION
Hope this is the right way to do things and let me preface this that I'm a big Kotlin amateur and needed a lot of "assistance" to get to the bottom of this. 

I've been using this plugin for CSS autocompletion and it's lovely. We recently switched to a new design-token package that we included in our project. For some reason this package was not being registered by the plugin. Went through the typical debugging steps. Reinstalling -> Forcing all modules instead of just `@import` -> Rebuilding Index & Deleting Cache. Nothing seem to help.

Using the lovely debug tool on the SCSS file that did the importing I noticed a couple things.
- No support for `@use` though this was fixed with switching to `@import` instead
- It mentioned 700+ variables found in the debugger but nothing was actually indexed
- Minified files that started with `/* some comment followed by */:root{--some-var:24px;...}` seemed to get skipped during indexing

So a couple of hours of debugging later and I got it to work with this fix. Probably won't win a beauty contest but didn't want to complain in an issue without trying to help solving the issue.
