### PR TITLE
fix: preserve alpha in 8-digit hex colors (fixes #22)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/) and semantic-versioning.
 
+## [1.8.6] – 2026-04-29
+
+Bug-fix release closing issue [#22](https://github.com/Stianlars1/css-vars-assistant/issues/22) reported by [@LordMaddhi](https://github.com/LordMaddhi).
+
+### Fixed
+- **8-digit hex colors with alpha (issue [#22](https://github.com/Stianlars1/css-vars-assistant/issues/22)):** A value like `--accent: #7F80FF1A` (modern CSS Color Level 4 `#RRGGBBAA` syntax) was rendered in the hover popup's *Hex* column as `#80FF1A`, looking like the first two characters had been silently dropped. Two compounding bugs were responsible and have both been corrected:
+  - `ColorParser.parseHexColor` treated the 8-digit form as Java's `#AARRGGBB` packed-int order (alpha *first*) instead of the CSS spec's `#RRGGBBAA` (alpha *last*). For `#7F80FF1A` that meant red was read as `80`, green as `FF`, blue as `1A`, and `7F` was assigned to alpha — so the parsed RGB was already wrong before any formatting happened.
+  - `ColorParser.colorToHex` and the local `Color.toHex()` extension in `buildHtmlDocument.kt` always emitted six digits (`#%02X%02X%02X`), unconditionally dropping any alpha that *had* been parsed. Combined with bug #1 this produced the visible `#80FF1A` truncation.
+- **4-digit hex shorthand `#RGBA` is now recognised** (was previously rejected as an unknown color, falling through to "no swatch / no Hex column"). Each digit is doubled, mirroring the existing 3-digit `#RGB` shorthand.
+
+### Changed
+- **Canonical hex output now preserves alpha when present:** `ColorParser.toHexString("#7F80FF1A")` round-trips identically. Fully-opaque colors still produce 6-digit hex (`#1E90FF`), so existing snapshots and the WebAIM contrast-checker URL are unaffected. The new `ColorParser.colorToRgbHex(color)` helper is available for callers that strictly need 6-digit RGB output.
+- **Color swatch in the hover popup now uses `rgb(...)` / `rgba(...)`** instead of hex so semi-transparent colors preview accurately. JBHtmlEditorKit's CSS parser is conservative on 8-digit hex; rgba() is broadly supported across the platform versions this plugin targets. Locale is forced to `Locale.ROOT` so the alpha float always uses a `.` decimal separator (CSS doesn't accept `,`-separated numbers in `nb_NO`/`de_DE`/etc.).
+
+### Notes
+- Regression coverage in `ColorParserTest`: the primary `#7F80FF1A` round-trip, the 4-digit `#RGBA` and `#RGBF` shorthand cases, the 8-digit fully-opaque collapse-to-6-digit case, the 8-digit fully-transparent round-trip, and explicit channel-position assertions verifying alpha is read from the LAST byte. The pre-existing rgba tests have been updated to assert the new alpha-preserving contract (`#FF008080` instead of the previous `#FF0080`).
+- No index rebuild or settings change required — pure parser/rendering fix, no on-disk format change.
+- Out of scope: `hsla()` alpha (currently dropped by `parseHslColor` into a default-255 `Color`) and CSS Color Level 4 `lab()` / `lch()` / `oklab()` / `oklch()` / `color()` / `color-mix()` syntaxes. Those are deliberately not addressed here to keep the change minimal and focused on the reported issue; a follow-up can take them on if requested.
+
 ## [1.8.5] – 2026-04-28
 
 Bug-fix release closing issue [#21](https://github.com/Stianlars1/css-vars-assistant/issues/21) reported by [@kolkinn](https://github.com/kolkinn).

--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,7 @@
 
 If you find CSS Variables Assistant helpful, please consider rating it on [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/27392-css-variables-assistant/reviews) ★★★★★ 🙏.
 
-**Version:** 1.8.5<br/>
+**Version:** 1.8.6<br/>
 **Compatible IDEs:** JetBrains IDEs with bundled JavaScript + CSS support — IntelliJ IDEA Ultimate, WebStorm, GoLand, PhpStorm, PyCharm Professional, and RubyMine.  
 **Author:** Stian Larsen  
 **Repo:** [github.com/Stianlars1/css-vars-assistant](https://github.com/Stianlars1/css-vars-assistant)
@@ -18,6 +18,18 @@ If you find CSS Variables Assistant helpful, please consider rating it on [JetBr
 
 
 Supercharge your CSS custom properties and preprocessor variables in JetBrains IDEs with advanced autocomplete, documentation, and debugging tools.
+---
+
+## ✨ What's new in 1.8.6
+
+Bug-fix release closing issue [#22](https://github.com/Stianlars1/css-vars-assistant/issues/22) reported by [@LordMaddhi](https://github.com/LordMaddhi).
+
+| Category                                                    | Highlights                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **🎨 8-digit hex colors with alpha now handled correctly** | Modern CSS Color Level 4 `#RRGGBBAA` values like `#7F80FF1A` no longer render as a truncated `#80FF1A` in the hover popup's *Hex* column. Two compounding bugs were fixed: the parser was reading alpha as the *first* byte (Java `#AARRGGBB` order) instead of the *last* byte per the CSS spec, and the formatter was unconditionally dropping alpha. The canonical hex output now preserves alpha when present (`#7F80FF1A` round-trips identically), and 4-digit `#RGBA` shorthand is recognised. Color swatches use `rgba()` so semi-transparent colors preview accurately. Fully-opaque colors still produce 6-digit hex, so existing snapshots and the WebAIM contrast-checker URL are unaffected. |
+
+[Full Changelog →](https://github.com/Stianlars1/css-vars-assistant/blob/main/CHANGELOG.MD)
+
 ---
 
 ## ✨ What's new in 1.8.5

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "com.stianlarsen"
-version = "1.8.5"
+version = "1.8.6"
 
 repositories {
     mavenCentral()
@@ -105,7 +105,17 @@ intellijPlatform {
   CSS variables, CSS custom properties, design tokens, <code>var(--token)</code>, <code>var()</code> autocomplete, Tailwind CSS, shadcn/ui, Radix UI, Radix Themes, Material Design tokens, MUI, Open Props, CSS cascade, <code>:root</code>, <code>calc()</code>, nested CSS variables, recursive variable resolution, dark mode tokens, theme variables, WebStorm CSS plugin, IntelliJ IDEA CSS autocomplete, JetBrains plugin design tokens, SCSS variables, Sass variables, LESS variables, <code>@import</code> resolution, JSDoc CSS, WCAG contrast checker, px equivalent, rem to px converter, hex to HSL, colour swatch, CSS-in-JS bridge.
 </p>
 
-<h3>✨ New in 1.8.5</h3>
+<h3>✨ New in 1.8.6</h3>
+<p>
+  Bug-fix release closing <a href="https://github.com/Stianlars1/css-vars-assistant/issues/22">issue #22</a> reported by <a href="https://github.com/LordMaddhi">@LordMaddhi</a>. 8-digit hex colors with alpha — the modern CSS Color Level 4 <code>#RRGGBBAA</code> syntax — are now handled correctly.
+</p>
+<ul>
+  <li><b>8-digit hex colors with alpha:</b> a value like <code>--accent: #7F80FF1A</code> no longer renders as a truncated <code>#80FF1A</code> in the hover popup's Hex column. Two compounding bugs were fixed: the parser was reading alpha as the <i>first</i> byte (Java <code>#AARRGGBB</code> packed-int order) instead of the <i>last</i> byte per the CSS spec, and the formatter was unconditionally dropping alpha. The canonical hex output now preserves alpha when present, and 4-digit <code>#RGBA</code> shorthand is recognised. Color swatches use <code>rgba()</code> so semi-transparent colors preview accurately.</li>
+  <li>Fully-opaque colors still produce 6-digit hex (<code>#1E90FF</code>), so existing snapshots and the WebAIM contrast-checker URL are unaffected.</li>
+  <li>Regression coverage in <code>ColorParserTest</code>: primary <code>#7F80FF1A</code> round-trip, 4-digit shorthand, full-opacity collapse-to-6-digit, fully-transparent round-trip, and explicit channel-position assertions verifying alpha is read from the LAST byte.</li>
+</ul>
+
+<h3>Previously in 1.8.5</h3>
 <p>
   Bug-fix release closing <a href="https://github.com/Stianlars1/css-vars-assistant/issues/21">issue #21</a> reported by <a href="https://github.com/kolkinn">@kolkinn</a>. Calculated tokens that reference multi-valued nested variables — the Radix Themes pattern <code>--space-2: calc(8px * var(--scaling))</code> — are now displayed correctly in the hover popup.
 </p>
@@ -185,6 +195,18 @@ intellijPlatform {
 """.trimIndent()
 
         changeNotes = """
+<h2>1.8.6 – 2026-04-29</h2>
+<h3>Fixed</h3>
+<ul>
+  <li><b>8-digit hex colors with alpha (issue <a href="https://github.com/Stianlars1/css-vars-assistant/issues/22">#22</a>, reported by @LordMaddhi):</b> a value like <code>--accent: #7F80FF1A</code> (modern CSS Color Level 4 <code>#RRGGBBAA</code> syntax) was rendered in the hover popup's Hex column as <code>#80FF1A</code>, looking like the first two characters had been silently dropped. Two compounding bugs were responsible and have both been corrected: <code>ColorParser.parseHexColor</code> treated the 8-digit form as Java's <code>#AARRGGBB</code> packed-int order (alpha <i>first</i>) instead of the CSS spec's <code>#RRGGBBAA</code> (alpha <i>last</i>), and <code>colorToHex</code> always emitted six digits, unconditionally dropping any alpha that <i>had</i> been parsed. Combined, this produced the visible <code>#80FF1A</code> truncation. The parser now reads alpha from the last byte, the formatter preserves alpha when present (<code>#7F80FF1A</code> round-trips identically), and 4-digit <code>#RGBA</code> shorthand is recognised.</li>
+  <li><b>Color swatch uses rgb()/rgba() instead of hex,</b> so semi-transparent colors preview accurately. Locale is forced to <code>Locale.ROOT</code> so the alpha float always uses a "." decimal separator (CSS doesn't accept ","-separated numbers in non-US locales).</li>
+</ul>
+<h3>Notes</h3>
+<ul>
+  <li>Fully-opaque colors still produce 6-digit hex (<code>#1E90FF</code>), so existing snapshots and the WebAIM contrast-checker URL are unaffected. The new <code>ColorParser.colorToRgbHex(color)</code> helper is available for callers that strictly need 6-digit RGB output.</li>
+  <li>Regression coverage in <code>ColorParserTest</code>: primary <code>#7F80FF1A</code> round-trip, 4-digit shorthand <code>#RGBA</code> and <code>#RGBF</code>, full-opacity collapse-to-6-digit, fully-transparent round-trip, explicit channel-position assertions, plus the pre-existing rgba tests updated to assert the new alpha-preserving contract (<code>#FF008080</code> instead of <code>#FF0080</code>).</li>
+  <li>No index rebuild or settings change required — pure parser/rendering fix.</li>
+</ul>
 <h2>1.8.5 – 2026-04-28</h2>
 <h3>Fixed</h3>
 <ul>

--- a/samples/issue-22/README.md
+++ b/samples/issue-22/README.md
@@ -1,0 +1,66 @@
+# Issue #22 — manual verification steps
+
+GitHub issue: <https://github.com/Stianlars1/css-vars-assistant/issues/22>
+
+## What broke
+
+A value like `--accent: #7F80FF1A` (modern CSS Color Level 4 `#RRGGBBAA` syntax)
+was rendered in the hover popup's `Hex` column as `#80FF1A`. Two compounding
+bugs were responsible:
+
+- `ColorParser.parseHexColor` treated the 8-digit form as Java's `#AARRGGBB`
+  packed-int order (alpha *first*) instead of the CSS spec's `#RRGGBBAA`
+  (alpha *last*). For `#7F80FF1A` that meant red was read as `80`, green as
+  `FF`, blue as `1A`, and `7F` was assigned to alpha.
+- `ColorParser.colorToHex` and the local `Color.toHex()` extension always
+  formatted six digits, unconditionally dropping any alpha that *had* been
+  parsed.
+
+Combined, both bugs produced the visible `#80FF1A` truncation reported by
+[@LordMaddhi](https://github.com/LordMaddhi).
+
+## How to verify the 1.8.6 fix locally
+
+1. Build the plugin:
+   ```bash
+   ./gradlew buildPlugin
+   ```
+   The signed zip lands in `build/distributions/cssvarsassistant-<version>.zip`.
+
+2. Sideload it into a fresh sandbox IDE:
+   ```bash
+   ./gradlew runIde
+   ```
+   Or install the zip manually via *Settings → Plugins → ⚙ → Install Plugin
+   from Disk…* in your normal IDE.
+
+3. Open this directory (`samples/issue-22`) as a project, or copy
+   `hex-alpha.css` into any existing project.
+
+4. Hover each `var(...)` reference inside `.card { … }`:
+
+   | Hover target | Expected `Hex` column | Expected swatch |
+   |---|---|---|
+   | `var(--accent-translucent)` | `#7f80ff1a` | translucent blue |
+   | `var(--backdrop-50)` | `#00000080` | half-transparent black |
+   | `var(--primary-12)` | `#ff008080` | half-transparent magenta |
+   | `var(--tooltip-bg)` | `#aabbccdd` | translucent grey-blue |
+   | `var(--solid-blue)` | `#1e90ff` | opaque blue |
+   | `var(--solid-with-FF-suffix)` | `#1e90ff` | opaque blue (8-digit `#1E90FFFF` collapses to 6 digits) |
+
+   The translucent rows MUST keep all eight hex digits — that was the
+   pre-fix bug. The opaque rows MUST still render as six digits so existing
+   snapshots and the WebAIM contrast-checker URL aren't disturbed.
+
+5. Trigger completion inside `background: var(--<caret>)`:
+   - The popup must show a swatch and Hex column for `--accent-translucent`,
+     `--backdrop-50`, `--tooltip-bg`, and `--primary-12`. Pre-fix the swatch
+     was missing for `--tooltip-bg` because 4-digit `#RGBA` shorthand was
+     silently rejected by the parser.
+
+## Automated coverage
+
+The same scenarios are locked in by
+`src/test/kotlin/ColorParserTest.kt`, which runs in `./gradlew test`.
+The file in this directory is for manual side-loaded validation only —
+it isn't bundled into the published plugin.

--- a/samples/issue-22/hex-alpha.css
+++ b/samples/issue-22/hex-alpha.css
@@ -1,0 +1,32 @@
+/* Reproducer for issue #22 — 8-digit hex with alpha
+ * https://github.com/Stianlars1/css-vars-assistant/issues/22
+ *
+ * Hover each `var(...)` reference inside `.card`. The hover popup's
+ * `Hex` column must echo the full alpha-aware value back, not the
+ * pre-fix truncated form.
+ */
+:root {
+    /* Reported case from @LordMaddhi: alpha is the LAST byte (1A),
+     * not the first (7F). Pre-fix this rendered as `#80FF1A`. */
+    --accent-translucent:    #7F80FF1A;
+
+    /* Common shadcn / Tailwind alpha overlays */
+    --backdrop-50:           #00000080; /* 50% black */
+    --primary-12:            rgba(255, 0, 128, 0.5); /* 50% magenta */
+
+    /* 4-digit shorthand was previously rejected silently */
+    --tooltip-bg:            #ABCD;     /* expands to #AABBCCDD */
+
+    /* Sanity rows — fully opaque must still render as 6-digit hex */
+    --solid-blue:            #1E90FF;
+    --solid-with-FF-suffix:  #1E90FFFF; /* should collapse to 6-digit */
+}
+
+.card {
+    background:    var(--accent-translucent);
+    box-shadow:    0 8px 24px var(--backdrop-50);
+    color:         var(--primary-12);
+    border:        1px solid var(--solid-blue);
+    --inherit:     var(--solid-with-FF-suffix);
+    --tooltip:     var(--tooltip-bg);
+}

--- a/src/main/kotlin/cssvarsassistant/documentation/ColorParser.kt
+++ b/src/main/kotlin/cssvarsassistant/documentation/ColorParser.kt
@@ -70,29 +70,37 @@ object ColorParser {
         return null
     }
 
+    // Issue #22 — CSS Color Level 4 hex syntaxes:
+    //   3-digit  #RGB      → #RRGGBB
+    //   4-digit  #RGBA     → #RRGGBBAA   (alpha LAST)
+    //   6-digit  #RRGGBB
+    //   8-digit  #RRGGBBAA              (alpha LAST)
+    //
+    // Earlier 8-digit handling treated the first byte as alpha (Java `Color.getRGB()`
+    // ARGB packed-int order), which produced wrong RGB plus a dropped alpha — the
+    // visible symptom in #22 was `#7F80FF1A` rendering as `#80FF1A` in the Hex
+    // column. The CSS spec orders alpha last, and we now follow it. 4-digit
+    // shorthand is also accepted; it was previously rejected because the
+    // `length == 8` branch was the only alpha-aware path.
     private fun parseHexColor(hex: String): Color? = try {
-        when (hex.length) {
-            3 -> Color(
-                Integer.valueOf(hex.substring(0, 1).repeat(2), 16),
-                Integer.valueOf(hex.substring(1, 2).repeat(2), 16),
-                Integer.valueOf(hex.substring(2, 3).repeat(2), 16)
-            )
-
-            6 -> Color(
-                Integer.valueOf(hex.substring(0, 2), 16),
-                Integer.valueOf(hex.substring(2, 4), 16),
-                Integer.valueOf(hex.substring(4, 6), 16)
-            )
-
-            8 -> Color(
-                Integer.valueOf(hex.substring(2, 4), 16),
-                Integer.valueOf(hex.substring(4, 6), 16),
-                Integer.valueOf(hex.substring(6, 8), 16),
-                Integer.valueOf(hex.substring(0, 2), 16)
-            )
-
-            else -> null
+        // Each digit doubled (`a` → `aa`) gives the canonical 6/8-digit form.
+        // We delegate to one branch with explicit RGBA byte slots, which keeps
+        // the parser DRY and removes the off-by-one trap in the original
+        // 8-digit branch.
+        val expanded = when (hex.length) {
+            3 -> hex.map { "$it$it" }.joinToString("") + "ff"            // #RGB    → #RRGGBBFF
+            4 -> hex.map { "$it$it" }.joinToString("")                    // #RGBA   → #RRGGBBAA
+            6 -> "${hex}ff"                                                // #RRGGBB → #RRGGBBFF
+            8 -> hex                                                       // #RRGGBBAA verbatim
+            else -> return null
         }
+
+        Color(
+            Integer.valueOf(expanded.substring(0, 2), 16), // R
+            Integer.valueOf(expanded.substring(2, 4), 16), // G
+            Integer.valueOf(expanded.substring(4, 6), 16), // B
+            Integer.valueOf(expanded.substring(6, 8), 16)  // A (CSS spec: last byte)
+        )
     } catch (_: Exception) {
         null
     }
@@ -204,16 +212,33 @@ object ColorParser {
     }
 
     /**
-     * Take any parsed [Color] and turn it into an uppercase "#RRGGBB" string.
-     * Alpha is dropped (for your swatch previews you can assume fully opaque).
+     * Canonical hex serialisation for a parsed [Color].
+     *
+     * Returns "#RRGGBB" for fully-opaque colors and "#RRGGBBAA" when the alpha
+     * channel is below 255 — matching the input grammar accepted by
+     * [parseCssColor]. Issue #22 fixed two compounding bugs here: the 8-digit
+     * input parser used Java's ARGB byte order (alpha first) instead of the
+     * CSS spec's RGBA order (alpha last), and this method silently dropped
+     * alpha on the way out, so `#7F80FF1A` round-tripped as `#80FF1A`.
      */
-    fun colorToHex(color: Color): String {
-        return String.format("#%02X%02X%02X", color.red, color.green, color.blue)
-    }
+    fun colorToHex(color: Color): String =
+        if (color.alpha == 255) {
+            String.format("#%02X%02X%02X", color.red, color.green, color.blue)
+        } else {
+            String.format("#%02X%02X%02X%02X", color.red, color.green, color.blue, color.alpha)
+        }
+
+    /**
+     * RGB-only hex without alpha — for callers like the WebAIM contrast link
+     * whose URL grammar only understands 6-digit hex.
+     */
+    fun colorToRgbHex(color: Color): String =
+        String.format("#%02X%02X%02X", color.red, color.green, color.blue)
 
     /**
      * Combines parsing + hex conversion in one call.
-     * Returns e.g. "#1A90FF" or null if it wasn't a valid color.
+     * Returns e.g. "#1A90FF" or "#7F80FF1A" when alpha is present, or null if
+     * it wasn't a valid color.
      */
     fun toHexString(input: String): String? {
         return parseCssColor(input)?.let(::colorToHex)

--- a/src/main/kotlin/cssvarsassistant/documentation/buildHtmlDocument.kt
+++ b/src/main/kotlin/cssvarsassistant/documentation/buildHtmlDocument.kt
@@ -243,11 +243,14 @@ fun buildHtmlDocument(
 
     /* ── WebAIM helper link for first colour found ───────────────────────── */
     sorted.firstNotNullOfOrNull { ColorParser.parseCssColor(it.resInfo.resolved) }?.let { c ->
+        // WebAIM expects strict 6-digit RGB. Issue #22: `Color.toHex()` is
+        // now alpha-aware and may emit 8 digits, so use the RGB-only helper
+        // here to keep the link grammar valid for semi-transparent colors.
         sb.append(
             """<p style='margin-top:10px'>
                        <a target="_blank"
                           href="https://webaim.org/resources/contrastchecker/?fcolor=${
-                c.toHex().removePrefix("#")
+                c.toHexRgb().removePrefix("#")
             }&bcolor=000000">
                           Check contrast on WebAIM Contrast Checker
                        </a></p>"""
@@ -260,7 +263,18 @@ fun buildHtmlDocument(
 
 
 /* ── tiny util helpers ─────────────────────────────────────────────────────── */
+// Issue #22 — the Hex column previously dropped the alpha byte, which combined
+// with the parser's wrong byte ordering produced the visible truncation
+// (`#7F80FF1A` → `#80FF1A`). We now emit "#rrggbb" when fully opaque and
+// "#rrggbbaa" otherwise, matching CSS Color Level 4. Lower-case is preserved
+// for backward compatibility with existing snapshot tests / hover output.
 fun java.awt.Color.toHex(): String =
+    if (alpha == 255) "#%02x%02x%02x".format(red, green, blue)
+    else "#%02x%02x%02x%02x".format(red, green, blue, alpha)
+
+// 6-digit lower-case hex for callers that cannot accept alpha — currently the
+// WebAIM contrast-checker URL, whose `fcolor=` param is RRGGBB-only.
+internal fun java.awt.Color.toHexRgb(): String =
     "#%02x%02x%02x".format(red, green, blue)
 
 fun contextLabel(ctx: String, isColor: Boolean, prettifyTheme: Boolean = true): String {
@@ -390,7 +404,22 @@ private fun humanise(raw: String): String {
 
 fun colorSwatchHtml(css: String): String =
     ColorParser.parseCssColor(css)?.let {
-        "<div style='background-color:${it.toHex()};border:1px solid #FFFFFF;display:inline-block;width:14px;height:14px;'></div>"
+        // Issue #22 — render the swatch with `rgba(...)` so semi-transparent
+        // colors (8-digit hex, rgba inputs) preview accurately. Previously the
+        // alpha was silently dropped, which made `#7F80FF1A` look like solid
+        // `#80FF1A` next to its (now-correct) "#7F80FF1A" Hex column entry.
+        // JBHtmlEditorKit's CSS parser is conservative; rgba() is broadly
+        // supported across the platform versions this plugin targets, while
+        // 8-digit hex is not. We force `Locale.ROOT` so the alpha float uses
+        // a "." decimal separator on every locale (CSS doesn't accept `,`).
+        val bg = if (it.alpha == 255) {
+            "rgb(${it.red},${it.green},${it.blue})"
+        } else {
+            "rgba(${it.red},${it.green},${it.blue},${
+                String.format(java.util.Locale.ROOT, "%.3f", it.alpha / 255.0)
+            })"
+        }
+        "<div style='background-color:$bg;border:1px solid #FFFFFF;display:inline-block;width:14px;height:14px;'></div>"
     } ?: "&nbsp;"
 
 /**

--- a/src/test/kotlin/ColorParserTest.kt
+++ b/src/test/kotlin/ColorParserTest.kt
@@ -2,6 +2,7 @@ package cssvarsassistant.documentation
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 class ColorParserTest {
@@ -18,9 +19,47 @@ class ColorParserTest {
         assertEquals("#AABBCC", ColorParser.toHexString("#ABC"))
     }
 
-    @Test fun `8‑digit hex drops alpha`() {
-        // #80FF0000 has 50% alpha + red ; toHexString should drop alpha and yield red
-        assertEquals("#FF0000", ColorParser.toHexString("#80FF0000"))
+    // Issue #22 — 8-digit hex (#RRGGBBAA per CSS Color Level 4) was previously
+    // mis-parsed as #AARRGGBB (Java ARGB int order) and the alpha was then
+    // silently dropped. Both bugs combined to truncate `#7F80FF1A` to
+    // `#80FF1A`. Round-trip through parseCssColor + colorToHex must now
+    // preserve alpha verbatim.
+    @Test fun `8-digit hex preserves alpha and uses CSS spec ordering`() {
+        // Reported value from the issue: alpha is the LAST byte (1A), not the first.
+        assertEquals("#7F80FF1A", ColorParser.toHexString("#7F80FF1A"))
+    }
+
+    @Test fun `8-digit hex round-trips when alpha is below full opacity`() {
+        // #80FF0000 means R=0x80, G=0xFF, B=0x00, A=0x00 (fully transparent
+        // yellow-green). The previous test expected `#FF0000` here because the
+        // parser put alpha first AND the formatter dropped alpha. Both have
+        // been corrected and now the round-trip is identity-preserving.
+        assertEquals("#80FF0000", ColorParser.toHexString("#80FF0000"))
+    }
+
+    @Test fun `8-digit hex with full opacity collapses to 6 digits`() {
+        // Alpha = FF means fully opaque; output stays 6-digit so existing
+        // callers and snapshots aren't disturbed when no alpha is present.
+        assertEquals("#1E90FF", ColorParser.toHexString("#1E90FFFF"))
+    }
+
+    @Test fun `4-digit hex shorthand expands with alpha`() {
+        // #RGBA → #RRGGBBAA (each digit doubled, just like 3-digit shorthand).
+        // Was previously unsupported (parser branched on 3/6/8 only).
+        assertEquals("#AABBCCDD", ColorParser.toHexString("#ABCD"))
+    }
+
+    @Test fun `4-digit hex shorthand with full opacity collapses to 6 digits`() {
+        assertEquals("#AABBCC", ColorParser.toHexString("#ABCF"))
+    }
+
+    @Test fun `parses 8-digit hex into Color object with correct channels`() {
+        val c = ColorParser.parseCssColor("#7F80FF1A")
+        assertNotNull(c)
+        assertEquals(0x7F, c!!.red,   "red byte must come from positions 1-2")
+        assertEquals(0x80, c.green, "green byte must come from positions 3-4")
+        assertEquals(0xFF, c.blue,  "blue byte must come from positions 5-6")
+        assertEquals(0x1A, c.alpha, "alpha byte must come from positions 7-8 (CSS spec)")
     }
 
     @Test fun `hex with surrounding whitespace`() {
@@ -38,13 +77,22 @@ class ColorParserTest {
         assertEquals("#FF0080", ColorParser.toHexString("rgb(100%,0%,50%)"))
     }
 
-    @Test fun `rgba slash alpha syntax`() {
-        // alpha 50% → 128 but dropped by toHexString()
-        assertEquals("#FF0080", ColorParser.toHexString("rgba(255 0 128 / 50%)"))
+    @Test fun `rgba slash alpha syntax preserves alpha`() {
+        // alpha 50% → 128 (= 0x80). Issue #22 — alpha is now preserved in the
+        // canonical hex output instead of being silently dropped.
+        assertEquals("#FF008080", ColorParser.toHexString("rgba(255 0 128 / 50%)"))
     }
 
-    @Test fun `rgba comma alpha syntax`() {
-        assertEquals("#00FF00", ColorParser.toHexString("rgba(0, 255, 0, 0.5)"))
+    @Test fun `rgba comma alpha syntax preserves alpha`() {
+        // 0.5 → 128 (= 0x80). Issue #22 — alpha preserved.
+        assertEquals("#00FF0080", ColorParser.toHexString("rgba(0, 255, 0, 0.5)"))
+    }
+
+    @Test fun `rgba with explicit full opacity stays 6 digits`() {
+        // Fully opaque rgba should still emit 6-digit hex so existing snapshots
+        // and downstream consumers (WebAIM contrast link, swatch background)
+        // are not disturbed for the common opaque case.
+        assertEquals("#FF0080", ColorParser.toHexString("rgba(255, 0, 128, 1)"))
     }
 
     // ----- HSL / HSLA -----


### PR DESCRIPTION
## Summary

Fixes #22 reported by @LordMaddhi.

A value like `--accent: #7F80FF1A` (modern CSS Color Level 4 `#RRGGBBAA` syntax) was rendered in the hover popup's `Hex` column as `#80FF1A`, looking like the first two characters were silently dropped. Two compounding bugs caused the visible truncation, and both have been corrected.

## Root cause

```
USER INPUT:  #7F80FF1A   (CSS spec: R=7F G=80 B=FF A=1A)

CURRENT PARSER (ColorParser.kt L87-92):
  alpha = substring(0,2) = "7F"   ← WRONG: alpha-first (Java #AARRGGBB int order)
  red   = substring(2,4) = "80"
  green = substring(4,6) = "FF"
  blue  = substring(6,8) = "1A"

CURRENT colorToHex (L210-212): "#%02X%02X%02X"  → ALPHA DROPPED
                               result: "#80FF1A"   ← user's bug
```

## Fix

1. **`ColorParser.parseHexColor`** is refactored to expand every input variant (`#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`) into a canonical 8-digit RGBA string and read R/G/B/A from fixed byte positions. CSS spec ordering (alpha last) is now correct, the off-by-one trap in the original 8-digit branch is gone, and 4-digit `#RGBA` shorthand is now recognised (was previously rejected — the parser only branched on lengths 3/6/8).
2. **`ColorParser.colorToHex`** (and the local `Color.toHex()` extension in `buildHtmlDocument.kt`) now emits `#RRGGBBAA` when alpha < 255 and stays 6-digit (`#RRGGBB`) for fully-opaque colors, so existing snapshots and the WebAIM contrast-checker URL are unaffected. A new `ColorParser.colorToRgbHex(color)` helper is added for callers that strictly need RGB-only output (currently the WebAIM link).
3. **Color swatch in the hover popup** now uses `rgb()` / `rgba()` with `Locale.ROOT` so semi-transparent colors preview accurately and the alpha float always uses a `.` decimal separator (CSS doesn't accept `,`-separated numbers in `nb_NO`/`de_DE`/etc.). JBHtmlEditorKit's CSS parser is conservative on 8-digit hex; rgba() is broadly supported.

## Test coverage

`src/test/kotlin/ColorParserTest.kt` gets six new tests plus updates to two pre-existing rgba tests:

- `8-digit hex preserves alpha and uses CSS spec ordering` — primary `#7F80FF1A` round-trip.
- `8-digit hex round-trips when alpha is below full opacity` — was previously asserting the old (buggy) alpha-stripping contract.
- `8-digit hex with full opacity collapses to 6 digits` — guards against accidental 8-digit output for opaque colors.
- `4-digit hex shorthand expands with alpha` and `…with full opacity collapses to 6 digits` — covers the previously-rejected case.
- `parses 8-digit hex into Color object with correct channels` — explicit per-channel assertions verifying alpha is read from the LAST byte.
- `rgba slash alpha syntax preserves alpha`, `rgba comma alpha syntax preserves alpha`, `rgba with explicit full opacity stays 6 digits` — the existing rgba tests now assert the new alpha-preserving contract (`#FF008080` instead of the previous `#FF0080`).

All 27 cases in the test file pass against the new implementation (verified by compiling `ColorParser.kt` with the cached `kotlin-stdlib.jar` from the project's IDEA dependency and running the assertions through the public API). Live `./gradlew test` was not run in the agent sandbox because the IntelliJ Platform Gradle plugin needs to extract the full IntelliJ Ultimate distribution (~7 GB), which exceeds the sandbox disk quota — please run `./gradlew check` locally before merging.

## Manual reproducer

`samples/issue-22/hex-alpha.css` + `samples/issue-22/README.md` — copy-paste fixture and side-loaded verification steps, mirroring the convention established by `samples/issue-21/`.

## Out of scope

- `hsla()` alpha (currently dropped by `parseHslColor` into a default-255 `Color`).
- CSS Color Level 4 `lab()` / `lch()` / `oklab()` / `oklch()` / `color()` / `color-mix()` syntaxes.

These were deliberately not addressed here to keep the change minimal and focused on the reported issue. Happy to take them on as follow-ups if requested.

## Release plan

Version bumped to **1.8.6** in `build.gradle.kts:17` and propagated through `README.MD` (header + "What's new" block) and `CHANGELOG.MD`. The marketplace `description` and `changeNotes` blocks in `build.gradle.kts` are also updated. **Publishing to JetBrains Marketplace and tagging a GitHub release are deferred** — per the task instructions for this scheduled run, no automated publish is initiated. When ready:

```bash
./gradlew clean buildPlugin verifyPlugin
# inspect build/distributions/cssvarsassistant-1.8.6.zip and the verifier report,
# then upload to https://plugins.jetbrains.com/plugin/27392
git tag v1.8.6 && git push origin v1.8.6
gh release create v1.8.6 --title "1.8.6 — fix: 8-digit hex alpha (issue #22)" --notes-file - <<EOF
…paste the 1.8.6 entry from CHANGELOG.MD…
EOF
```

Closes #22.
