### PR TITLE
fix: resolve SCSS/LESS aliases to CSS vars in hover/completion (#26)

### DIFF
--- a/src/main/kotlin/cssvarsassistant/completion/CssVariableCompletion.kt
+++ b/src/main/kotlin/cssvarsassistant/completion/CssVariableCompletion.kt
@@ -15,6 +15,7 @@ import com.intellij.util.ProcessingContext
 import com.intellij.util.indexing.FileBasedIndex
 import com.intellij.util.ui.ColorIcon
 import cssvarsassistant.documentation.ColorParser
+import cssvarsassistant.documentation.findPreprocessorVariableValue
 import cssvarsassistant.documentation.lastLocalValueInFile
 import cssvarsassistant.documentation.resolveVarValue
 import cssvarsassistant.feedback.RatePromptService
@@ -24,7 +25,6 @@ import cssvarsassistant.index.PREPROCESSOR_VARIABLE_INDEX_NAME
 import cssvarsassistant.model.DocParser
 import cssvarsassistant.settings.CssVarsAssistantSettings
 import cssvarsassistant.util.CssTextUtil
-import cssvarsassistant.util.PreprocessorUtil
 import cssvarsassistant.util.ScopeUtil
 import cssvarsassistant.util.ValueUtil
 import java.awt.Component
@@ -458,7 +458,8 @@ class CssVariableCompletion : CompletionContributor() {
                     .distinct()
                 if (rawValues.isEmpty()) return@mapNotNull null
 
-                val resolution = PreprocessorUtil.resolveVariableWithSteps(project, key, scope)
+                val resolution = findPreprocessorVariableValue(project, key)
+                    ?: return@mapNotNull null
                 val mainValue = resolution.resolved.trim()
                 val didResolve = rawValues.none { it.trim() == mainValue }
                 Entry(

--- a/src/main/kotlin/cssvarsassistant/documentation/CssVariableDocumentationService.kt
+++ b/src/main/kotlin/cssvarsassistant/documentation/CssVariableDocumentationService.kt
@@ -15,7 +15,6 @@ import cssvarsassistant.index.PREPROCESSOR_VARIABLE_INDEX_NAME
 import cssvarsassistant.model.DocParser
 import cssvarsassistant.settings.CssVarsAssistantSettings
 import cssvarsassistant.util.CssTextUtil
-import cssvarsassistant.util.PreprocessorUtil
 import cssvarsassistant.util.RankUtil.rank
 import cssvarsassistant.util.ScopeUtil
 import cssvarsassistant.util.ValueUtil
@@ -23,6 +22,7 @@ import kotlin.math.roundToInt
 
 object CssVariableDocumentationService {
     private val logger = Logger.getInstance(CssVariableCompletion::class.java)
+    private val cssVarReferenceRegex = Regex("""^\s*var\(\s*(--[\w-]+)\s*\)\s*$""")
 
     fun generateDocumentation(element: PsiElement, varName: String): String? {
         try {
@@ -219,7 +219,18 @@ object CssVariableDocumentationService {
 
         if (rawEntries.isEmpty()) return null
 
-        val resolution = PreprocessorUtil.resolveVariableWithSteps(project, varName, scope)
+        val directCssVarAlias = rawEntries
+            .asSequence()
+            .mapNotNull { extractCssVarReference(it.value) }
+            .firstOrNull()
+        if (directCssVarAlias != null) {
+            generateDocumentation(element, directCssVarAlias)?.let { return it }
+        }
+
+        val resolution = findPreprocessorVariableValue(project, varName) ?: ResolutionInfo(varName, varName)
+        extractCssVarReference(resolution.resolved)?.let { cssAlias ->
+            generateDocumentation(element, cssAlias)?.let { return it }
+        }
         val rows = listOf(
             HoverRow(
                 context = "default",
@@ -326,7 +337,8 @@ object CssVariableDocumentationService {
             .getValues(PREPROCESSOR_VARIABLE_INDEX_NAME, varName, scope)
         if (values.isEmpty()) return null
 
-        val resolutionInfo = PreprocessorUtil.resolveVariableWithSteps(project, varName, scope)
+        val resolutionInfo = findPreprocessorVariableValue(project, varName)
+            ?: ResolutionInfo(varName, varName)
         return if (resolutionInfo.steps.isNotEmpty() && resolutionInfo.original != resolutionInfo.resolved) {
             "Resolution: ${resolutionInfo.steps.joinToString(" → ")} → ${resolutionInfo.resolved}"
         } else {
@@ -345,4 +357,7 @@ object CssVariableDocumentationService {
             val numericRaw = entry.resInfo.resolved.replace(Regex("[^0-9.+\\-]"), "").toDoubleOrNull() ?: pxVal
             unit != "px" || pxVal.roundToInt() != numericRaw.roundToInt()
         }
+
+    private fun extractCssVarReference(value: String): String? =
+        cssVarReferenceRegex.find(value)?.groupValues?.get(1)
 }

--- a/src/main/kotlin/cssvarsassistant/documentation/CssVariableDocumentationService.kt
+++ b/src/main/kotlin/cssvarsassistant/documentation/CssVariableDocumentationService.kt
@@ -5,7 +5,9 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.indexing.FileBasedIndex
 import cssvarsassistant.completion.CssVariableCompletion
 import cssvarsassistant.index.CSS_VARIABLE_INDEXER_NAME
@@ -15,6 +17,7 @@ import cssvarsassistant.index.PREPROCESSOR_VARIABLE_INDEX_NAME
 import cssvarsassistant.model.DocParser
 import cssvarsassistant.settings.CssVarsAssistantSettings
 import cssvarsassistant.util.CssTextUtil
+import cssvarsassistant.util.PreprocessorUtil
 import cssvarsassistant.util.RankUtil.rank
 import cssvarsassistant.util.ScopeUtil
 import cssvarsassistant.util.ValueUtil
@@ -22,7 +25,6 @@ import kotlin.math.roundToInt
 
 object CssVariableDocumentationService {
     private val logger = Logger.getInstance(CssVariableCompletion::class.java)
-    private val cssVarReferenceRegex = Regex("""^\s*var\(\s*(--[\w-]+)\s*\)\s*$""")
 
     fun generateDocumentation(element: PsiElement, varName: String): String? {
         try {
@@ -30,11 +32,30 @@ object CssVariableDocumentationService {
             if (DumbService.isDumb(project)) return null
             ProgressManager.checkCanceled()
 
-            val settings = CssVarsAssistantSettings.getInstance()
             if (isPreprocessorVariable(varName)) {
                 return generatePreprocessorDocumentation(element, varName)
             }
 
+            return generateCssVarDocumentation(element, displayName = varName, lookupName = varName)
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: Exception) {
+            logger.error("Error generating documentation", e)
+            return null
+        }
+    }
+
+    private fun generateCssVarDocumentation(
+        element: PsiElement,
+        displayName: String,
+        lookupName: String
+    ): String? {
+        try {
+            val project = element.project
+            if (DumbService.isDumb(project)) return null
+            ProgressManager.checkCanceled()
+
+            val settings = CssVarsAssistantSettings.getInstance()
             val cssScope = ScopeUtil.effectiveCssIndexingScope(project, settings)
 
             // Phase 8b / issue #19: `processValues` yields `(VirtualFile, packed)`
@@ -46,7 +67,7 @@ object CssVariableDocumentationService {
             val rawEntries = mutableListOf<RawEntryWithFile>()
             FileBasedIndex.getInstance().processValues(
                 CSS_VARIABLE_INDEXER_NAME,
-                varName,
+                lookupName,
                 null,
                 { file, packed ->
                     CssVariableIndexValueCodec.decodePacked(packed).forEach { decoded ->
@@ -74,7 +95,7 @@ object CssVariableDocumentationService {
 
             // Get local file text and find local values
             val activeText = element.containingFile.text
-            val localValues = extractLocalValues(activeText, varName)
+            val localValues = extractLocalValues(activeText, lookupName)
 
             // Mark entries as local or imported
             val enrichedEntries = parsed.map { entry ->
@@ -160,7 +181,7 @@ object CssVariableDocumentationService {
                 )
             }
 
-            return buildHtmlDocument(varName, doc, hoverRows, showPixelCol, winnerIndex)
+            return buildHtmlDocument(displayName, doc, hoverRows, showPixelCol, winnerIndex)
 
 
         } catch (e: ProcessCanceledException) {
@@ -219,18 +240,20 @@ object CssVariableDocumentationService {
 
         if (rawEntries.isEmpty()) return null
 
-        val directCssVarAlias = rawEntries
-            .asSequence()
-            .mapNotNull { extractCssVarReference(it.value) }
-            .firstOrNull()
-        if (directCssVarAlias != null) {
-            generateDocumentation(element, directCssVarAlias)?.let { return it }
+        findCssAliasForPreprocessor(
+            project = project,
+            varName = varName,
+            scope = scope,
+            rawValues = rawEntries.map { it.value }
+        )?.let { cssVarName ->
+            generateCssVarDocumentation(
+                element,
+                displayName = "$varName → var($cssVarName)",
+                lookupName = cssVarName
+            )?.let { return it }
         }
 
         val resolution = findPreprocessorVariableValue(project, varName) ?: ResolutionInfo(varName, varName)
-        extractCssVarReference(resolution.resolved)?.let { cssAlias ->
-            generateDocumentation(element, cssAlias)?.let { return it }
-        }
         val rows = listOf(
             HoverRow(
                 context = "default",
@@ -249,6 +272,18 @@ object CssVariableDocumentationService {
             showPixelCol = shouldShowPixelColumn(rows),
             winnerIndex = 0
         )
+    }
+
+    private fun findCssAliasForPreprocessor(
+        project: Project,
+        varName: String,
+        scope: GlobalSearchScope,
+        rawValues: Iterable<String>
+    ): String? {
+        rawValues.firstNotNullOfOrNull { extractCssVarAlias(it) }?.let { return it }
+
+        val preprocessorOnlyResolution = PreprocessorUtil.resolveVariableWithSteps(project, varName, scope)
+        return extractCssVarAlias(preprocessorOnlyResolution.resolved)
     }
 
     private fun extractLocalValues(fileText: String, varName: String): Set<String> {
@@ -337,6 +372,8 @@ object CssVariableDocumentationService {
             .getValues(PREPROCESSOR_VARIABLE_INDEX_NAME, varName, scope)
         if (values.isEmpty()) return null
 
+        generateCssAliasHint(project, varName, scope, values)?.let { return it }
+
         val resolutionInfo = findPreprocessorVariableValue(project, varName)
             ?: ResolutionInfo(varName, varName)
         return if (resolutionInfo.steps.isNotEmpty() && resolutionInfo.original != resolutionInfo.resolved) {
@@ -344,6 +381,39 @@ object CssVariableDocumentationService {
         } else {
             "$varName → ${resolutionInfo.resolved}"
         }
+    }
+
+    private fun generateCssAliasHint(
+        project: Project,
+        varName: String,
+        scope: GlobalSearchScope,
+        rawValues: Iterable<String>
+    ): String? {
+        val preprocessorOnlyResolution = PreprocessorUtil.resolveVariableWithSteps(project, varName, scope)
+        val cssVarName = rawValues.firstNotNullOfOrNull { extractCssVarAlias(it) }
+            ?: extractCssVarAlias(preprocessorOnlyResolution.resolved)
+            ?: return null
+
+        val cssScope = ScopeUtil.effectiveCssIndexingScope(
+            project,
+            CssVarsAssistantSettings.getInstance()
+        )
+        val rawEntries = CssVariableIndexValueCodec.decode(
+            FileBasedIndex.getInstance().getValues(CSS_VARIABLE_INDEXER_NAME, cssVarName, cssScope)
+        )
+        if (rawEntries.isEmpty()) return null
+
+        val rawValue = rawEntries.find { it.context == "default" }?.value
+            ?: rawEntries.first().value
+        val cssInfo = resolveVarValue(project, rawValue)
+        val prefixSteps = preprocessorOnlyResolution.steps.ifEmpty { listOf(varName) }
+        val cssSteps = if (cssInfo.steps.isNotEmpty() && cssInfo.original != cssInfo.resolved) {
+            cssInfo.steps + cssInfo.resolved
+        } else {
+            listOf(cssInfo.resolved)
+        }
+
+        return "Resolution: ${(prefixSteps + "var($cssVarName)" + cssSteps).joinToString(" → ")}"
     }
 
     private fun isPreprocessorVariable(varName: String): Boolean =
@@ -358,6 +428,4 @@ object CssVariableDocumentationService {
             unit != "px" || pxVal.roundToInt() != numericRaw.roundToInt()
         }
 
-    private fun extractCssVarReference(value: String): String? =
-        cssVarReferenceRegex.find(value)?.groupValues?.get(1)
 }

--- a/src/main/kotlin/cssvarsassistant/documentation/docHelpers.kt
+++ b/src/main/kotlin/cssvarsassistant/documentation/docHelpers.kt
@@ -33,7 +33,7 @@ fun resolveVarValue(
     try {
         ProgressManager.checkCanceled()
 
-        Regex("""var\(\s*(--[\w-]+)\s*\)""").find(raw)?.let { m ->
+        Regex("""var\(\s*(--[\w-]+)\s*(?:,[^()]*)?\)""").find(raw)?.let { m ->
             val ref = m.groupValues[1]
             if (ref !in visited) {
                 val newSteps = steps + "var($ref)"
@@ -111,7 +111,7 @@ fun findPreprocessorVariableValue(
             emptySet(),
             currentSteps
         )
-        if (Regex("""var\(\s*--[\w-]+\s*\)""").containsMatchIn(resolution.resolved)) {
+        if (extractCssVarAlias(resolution.resolved) != null) {
             return resolveVarValue(
                 project = project,
                 raw = resolution.resolved,
@@ -186,3 +186,10 @@ fun lastLocalValueInFile(fileText: String, varName: String): String? =
         .findAll(CssTextUtil.stripCssComments(fileText))
         .map { it.groupValues[1].trim() }
         .lastOrNull()
+
+private val PURE_CSS_VAR_ALIAS = Regex(
+    """^\s*var\(\s*(--[\w-]+)\s*(?:,[^()]*)?\)\s*;?\s*$"""
+)
+
+fun extractCssVarAlias(rawValue: String): String? =
+    PURE_CSS_VAR_ALIAS.find(rawValue)?.groupValues?.get(1)

--- a/src/main/kotlin/cssvarsassistant/documentation/docHelpers.kt
+++ b/src/main/kotlin/cssvarsassistant/documentation/docHelpers.kt
@@ -111,6 +111,13 @@ fun findPreprocessorVariableValue(
             emptySet(),
             currentSteps
         )
+        if (Regex("""var\(\s*--[\w-]+\s*\)""").containsMatchIn(resolution.resolved)) {
+            return resolveVarValue(
+                project = project,
+                raw = resolution.resolved,
+                steps = resolution.steps
+            )
+        }
         return resolution
     } catch (e: ProcessCanceledException) {
         throw e

--- a/src/test/kotlin/cssvarsassistant/completion/CssVariableCompletionHarnessTest.kt
+++ b/src/test/kotlin/cssvarsassistant/completion/CssVariableCompletionHarnessTest.kt
@@ -447,6 +447,67 @@ class CssVariableCompletionHarnessTest : CssVarsAssistantPlatformTestCase() {
         assertTrue(html, html.contains("8px"))
     }
 
+    fun testScssAliasToCssVarDocumentationShowsCssVariableContexts() {
+        configureProjectFile(
+            "app.scss",
+            """
+            [data-theme='dark'] {
+              --foo: red;
+            }
+
+            [data-theme='light'] {
+              --foo: blue;
+            }
+
+            ${'$'}foo: var(--foo);
+
+            .test {
+              color: ${'$'}foo<caret>;
+            }
+            """
+        )
+
+        val variableElement = requireNotNull(myFixture.file.findElementAt(myFixture.caretOffset - 1))
+        val html = CssVariableDocumentationService.generateDocumentation(variableElement, "\$foo")
+
+        requireNotNull(html)
+        assertTrue(html, html.contains("--foo"))
+        assertTrue(html, html.contains("red"))
+        assertTrue(html, html.contains("blue"))
+    }
+
+    fun testScssVariableCompletionResolvesAliasToCssCustomPropertyValue() {
+        addProjectStylesheet(
+            "tokens.scss",
+            """
+            :root {
+              --surface: #123456;
+            }
+
+            ${'$'}surface-token: var(--surface);
+            ${'$'}surface-alt: #0f0f0f;
+            """
+        )
+
+        val lookups = completeCssVariablesInProjectFile(
+            "app.scss",
+            """
+            .card {
+              color: ${'$'}sur<caret>;
+            }
+            """
+        )
+
+        assertTrue(
+            "lookups=${lookups.joinToString()}",
+            lookups.any {
+                it.lookupString == "\$surface-token" &&
+                    it.itemText == "\$surface-token" &&
+                    it.typeText == "#123456 ↗"
+            }
+        )
+    }
+
     fun testScssVariableDocumentationResolvesImportedNodeModulesAliasChain() {
         updateSettings {
             indexingScope = CssVarsAssistantSettings.IndexingScope.PROJECT_WITH_IMPORTS

--- a/src/test/kotlin/cssvarsassistant/completion/CssVariableCompletionHarnessTest.kt
+++ b/src/test/kotlin/cssvarsassistant/completion/CssVariableCompletionHarnessTest.kt
@@ -471,9 +471,62 @@ class CssVariableCompletionHarnessTest : CssVarsAssistantPlatformTestCase() {
         val html = CssVariableDocumentationService.generateDocumentation(variableElement, "\$foo")
 
         requireNotNull(html)
+        assertTrue(html, html.contains("\$foo"))
         assertTrue(html, html.contains("--foo"))
         assertTrue(html, html.contains("red"))
         assertTrue(html, html.contains("blue"))
+    }
+
+    fun testScssAliasWithFallbackDocumentationShowsCssVariableContextsAndHint() {
+        configureProjectFile(
+            "app.scss",
+            """
+            :root {
+              --surface: #112233;
+            }
+
+            ${'$'}surface-token: var(--surface, #ffffff);
+
+            .test {
+              color: ${'$'}surface-token<caret>;
+            }
+            """
+        )
+
+        val variableElement = requireNotNull(myFixture.file.findElementAt(myFixture.caretOffset - 1))
+        val html = CssVariableDocumentationService.generateDocumentation(variableElement, "\$surface-token")
+
+        requireNotNull(html)
+        assertTrue(html, html.contains("\$surface-token"))
+        assertTrue(html, html.contains("--surface"))
+        assertTrue(html, html.contains("#112233"))
+
+        val hint = CssVariableDocumentationService.generateHint(variableElement, "\$surface-token")
+        assertEquals("Resolution: \$surface-token → var(--surface) → #112233", hint)
+    }
+
+    fun testCompoundScssValueWithCssVarDocumentationStaysLiteral() {
+        configureProjectFile(
+            "app.scss",
+            """
+            :root {
+              --surface: #112233;
+            }
+
+            ${'$'}surface-border: 1px solid var(--surface);
+
+            .test {
+              border: ${'$'}surface-border<caret>;
+            }
+            """
+        )
+
+        val variableElement = requireNotNull(myFixture.file.findElementAt(myFixture.caretOffset - 1))
+        val html = CssVariableDocumentationService.generateDocumentation(variableElement, "\$surface-border")
+
+        requireNotNull(html)
+        assertTrue(html, html.contains("\$surface-border"))
+        assertTrue(html, html.contains("1px solid var(--surface)"))
     }
 
     fun testScssVariableCompletionResolvesAliasToCssCustomPropertyValue() {

--- a/src/test/kotlin/cssvarsassistant/documentation/DocHelpersResolveVarValueTest.kt
+++ b/src/test/kotlin/cssvarsassistant/documentation/DocHelpersResolveVarValueTest.kt
@@ -200,6 +200,42 @@ class DocHelpersResolveVarValueTest : CssVarsAssistantPlatformTestCase() {
         assertEquals(listOf("\$surface-token", "var(--surface)"), info.steps)
     }
 
+    fun testScssAliasWithFallbackToCssCustomPropertyResolvesThroughCssVariable() {
+        addProjectStylesheet(
+            "tokens.scss",
+            """
+            :root {
+              --surface: #112233;
+            }
+
+            ${'$'}surface-token: var(--surface, #ffffff);
+            """
+        )
+
+        val info = resolveVarValue(project, "\$surface-token")
+
+        assertEquals("#112233", info.resolved)
+        assertEquals(listOf("\$surface-token", "var(--surface)"), info.steps)
+    }
+
+    fun testCompoundScssValueWithCssCustomPropertyStaysLiteral() {
+        addProjectStylesheet(
+            "tokens.scss",
+            """
+            :root {
+              --surface: #112233;
+            }
+
+            ${'$'}surface-border: 1px solid var(--surface);
+            """
+        )
+
+        val info = resolveVarValue(project, "\$surface-border")
+
+        assertEquals("1px solid var(--surface)", info.resolved)
+        assertEquals(listOf("\$surface-border"), info.steps)
+    }
+
     fun testLessAliasToCssCustomPropertyResolvesThroughCssVariable() {
         addProjectStylesheet(
             "tokens.less",

--- a/src/test/kotlin/cssvarsassistant/documentation/DocHelpersResolveVarValueTest.kt
+++ b/src/test/kotlin/cssvarsassistant/documentation/DocHelpersResolveVarValueTest.kt
@@ -182,6 +182,42 @@ class DocHelpersResolveVarValueTest : CssVarsAssistantPlatformTestCase() {
         )
     }
 
+    fun testScssAliasToCssCustomPropertyResolvesThroughCssVariable() {
+        addProjectStylesheet(
+            "tokens.scss",
+            """
+            :root {
+              --surface: #112233;
+            }
+
+            ${'$'}surface-token: var(--surface);
+            """
+        )
+
+        val info = resolveVarValue(project, "\$surface-token")
+
+        assertEquals("#112233", info.resolved)
+        assertEquals(listOf("\$surface-token", "var(--surface)"), info.steps)
+    }
+
+    fun testLessAliasToCssCustomPropertyResolvesThroughCssVariable() {
+        addProjectStylesheet(
+            "tokens.less",
+            """
+            :root {
+              --surface: #445566;
+            }
+
+            @surface-token: var(--surface);
+            """
+        )
+
+        val info = resolveVarValue(project, "@surface-token")
+
+        assertEquals("#445566", info.resolved)
+        assertEquals(listOf("@surface-token", "var(--surface)"), info.steps)
+    }
+
     fun testPrefixedScssReferenceDoesNotFallbackToLessVariableWithSameBareName() {
         addProjectStylesheet(
             "tokens.less",


### PR DESCRIPTION
Closes #26

### Summary

- Fixes alias resolution for preprocessor variables like `$foo: var(--foo)` and `@foo: var(--foo)` so they continue into CSS custom property resolution.
- Routes preprocessor hover/hint/completion through the bridged resolver path, preserving resolution steps and showing fully resolved values.
- Enables $foo hover docs to reuse CSS variable documentation output for direct `var(--foo)` aliases, including themed context table values.
- Adds regression coverage for SCSS/LESS alias-to-CSS-var behavior in resolver and completion/documentation harness tests.